### PR TITLE
Add email viewing feature

### DIFF
--- a/backend/src/main/java/com/sentineliq/backend/controller/EmailController.java
+++ b/backend/src/main/java/com/sentineliq/backend/controller/EmailController.java
@@ -1,0 +1,28 @@
+package com.sentineliq.backend.controller;
+
+import com.sentineliq.backend.dto.EmailDTO;
+import com.sentineliq.backend.model.Email;
+import com.sentineliq.backend.repository.EmailRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api")
+public class EmailController {
+
+    @Autowired
+    private EmailRepository emailRepository;
+
+    @GetMapping("/emailAccounts/{accountId}/emails")
+    public ResponseEntity<List<EmailDTO>> getEmailsByAccount(@PathVariable Long accountId) {
+        List<Email> emails = emailRepository.findByEmailAccountIdOrderByReceivedAtDesc(accountId);
+        List<EmailDTO> dtos = emails.stream()
+                .map(EmailDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtos);
+    }
+}

--- a/backend/src/main/java/com/sentineliq/backend/dto/EmailDTO.java
+++ b/backend/src/main/java/com/sentineliq/backend/dto/EmailDTO.java
@@ -1,0 +1,35 @@
+package com.sentineliq.backend.dto;
+
+import com.sentineliq.backend.model.Email;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailDTO {
+    private Long id;
+    private String subject;
+    private String sender;
+    private String body;
+    private LocalDateTime receivedAt;
+    private Boolean isSpam;
+    private Integer trustScore;
+
+    public static EmailDTO fromEntity(Email email) {
+        return EmailDTO.builder()
+                .id(email.getId())
+                .subject(email.getSubject())
+                .sender(email.getSender())
+                .body(email.getBody())
+                .receivedAt(email.getReceivedAt())
+                .isSpam(email.getIsSpam())
+                .trustScore(email.getTrustScore())
+                .build();
+    }
+}

--- a/frontend/src/app/user_pages/protected/emailviewer/page.tsx
+++ b/frontend/src/app/user_pages/protected/emailviewer/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import EmailCard from '@/components/EmailCard';
+
+interface Email {
+  id: number;
+  sender: string;
+  subject: string;
+  body: string;
+  receivedAt: string;
+  isSpam: boolean;
+  trustScore: number;
+}
+
+export default function EmailViewerPage() {
+  const searchParams = useSearchParams();
+  const accountId = searchParams.get('accountId');
+  const [emails, setEmails] = useState<Email[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchEmails = async () => {
+      if (!accountId) return;
+      try {
+        const res = await fetch(
+          `http://localhost:8080/api/emailAccounts/${accountId}/emails`,
+          { credentials: 'include' }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setEmails(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch emails', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEmails();
+  }, [accountId]);
+
+  if (!accountId) {
+    return <div className="p-4">No inbox selected.</div>;
+  }
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-3">
+      {emails.map((email) => (
+        <EmailCard
+          key={email.id}
+          sender={email.sender}
+          subject={email.subject}
+          trustScore={email.trustScore}
+          intent="Unknown"
+          spam={email.isSpam}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add controller endpoint to return stored emails
- create DTO for returning Email data
- implement frontend page to view emails via EmailCard component

## Testing
- `mvn -f backend/pom.xml -DskipTests package` *(fails: Non-resolvable parent POM - network unreachable)*
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font resources)*

------
https://chatgpt.com/codex/tasks/task_e_6841dc826bf4832eb087203da99a3570